### PR TITLE
Bug fix for XPRA authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:focal
-MAINTAINER Juan Luis Baptiste <juan.baptiste@gmail.com>
+LABEL maintainer="juan.baptiste@gmail.com"
 ENV DISPLAY=:100
 ENV WEB_VIEW_PORT 10000
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   wallet:
-    image: juanluisbaptiste/xpra-base:latest
+    image: gentoorax/xpra-base:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   wallet:
-    image: gentoorax/xpra-base:latest
+    image: juanluisbaptiste/xpra-base:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,8 +24,8 @@ if [ "${ENABLE_WEB_VIEW}" == "yes" ]; then
     ${XPRA}
   else
     #Credentials have been provided so create password file and link to it
-    python /usr/lib/python2.7/dist-packages/xpra/server/auth/sqlite_auth.py ./auth.sdb create
-    python /usr/lib/python2.7/dist-packages/xpra/server/auth/sqlite_auth.py ./auth.sdb add ${XPRA_USER} ${XPRA_PASSWORD}
+    python /usr/lib/python3/dist-packages/xpra/server/auth/sqlite_auth.py ./auth.sdb create
+    python /usr/lib/python3/dist-packages/xpra/server/auth/sqlite_auth.py ./auth.sdb add ${XPRA_USER} ${XPRA_PASSWORD}
     XPRA="${XPRA} --auth=sqlite:filename=./auth.sdb --ws-auth=sqlite:filename=./auth.sdb --tcp-auth=sqlite:filename=./auth.sdb"
     ${XPRA}
   fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,9 +24,9 @@ if [ "${ENABLE_WEB_VIEW}" == "yes" ]; then
     ${XPRA}
   else
     #Credentials have been provided so create password file and link to it
-    python /usr/lib/python3/dist-packages/xpra/server/auth/sqlite_auth.py ./auth.sdb create
-    python /usr/lib/python3/dist-packages/xpra/server/auth/sqlite_auth.py ./auth.sdb add ${XPRA_USER} ${XPRA_PASSWORD}
-    XPRA="${XPRA} --auth=sqlite:filename=./auth.sdb --ws-auth=sqlite:filename=./auth.sdb --tcp-auth=sqlite:filename=./auth.sdb"
+    python3 /usr/lib/python3/dist-packages/xpra/server/auth/sqlite_auth.py /home/user/auth.sdb create
+    python3 /usr/lib/python3/dist-packages/xpra/server/auth/sqlite_auth.py /home/user/auth.sdb add ${XPRA_USER} ${XPRA_PASSWORD}
+    XPRA="${XPRA} --auth=sqlite:filename=/home/user/auth.sdb --ws-auth=sqlite:filename=/home/user/auth.sdb --tcp-auth=sqlite:filename=/home/user/auth.sdb"
     ${XPRA}
   fi
 


### PR DESCRIPTION
The upgrade to focal has also updated python and broken the XPRA authentication I wrote some time ago. The below changes will resolve this. Also maintainer field is deprecated in favour of LABEL these days.