### PR TITLE
Resolved bug from focal upgrade reg python version

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,9 +24,9 @@ if [ "${ENABLE_WEB_VIEW}" == "yes" ]; then
     ${XPRA}
   else
     #Credentials have been provided so create password file and link to it
-    python /usr/lib/python2.7/dist-packages/xpra/server/auth/sqlite_auth.py ./auth.sdb create
-    python /usr/lib/python2.7/dist-packages/xpra/server/auth/sqlite_auth.py ./auth.sdb add ${XPRA_USER} ${XPRA_PASSWORD}
-    XPRA="${XPRA} --auth=sqlite:filename=./auth.sdb --ws-auth=sqlite:filename=./auth.sdb --tcp-auth=sqlite:filename=./auth.sdb"
+    python3 /usr/lib/python3/dist-packages/xpra/server/auth/sqlite_auth.py /home/user/auth.sdb create
+    python3 /usr/lib/python3/dist-packages/xpra/server/auth/sqlite_auth.py /home/user/auth.sdb add ${XPRA_USER} ${XPRA_PASSWORD}
+    XPRA="${XPRA} --auth=sqlite:filename=/home/user/auth.sdb --ws-auth=sqlite:filename=/home/user/auth.sdb --tcp-auth=sqlite:filename=/home/user/auth.sdb"
     ${XPRA}
   fi
 


### PR DESCRIPTION
XPRA python packages have moved to python3 in the focal update breaking references to the sqlite_auth.py. The references have now been updated in this request. Furthermore, relative references to the password database file were no longer working, absolute paths now used.